### PR TITLE
Re-added --quiet-pull argument to compose up step

### DIFF
--- a/make/docker.mk
+++ b/make/docker.mk
@@ -18,6 +18,11 @@ config: ## Show docker-compose config
 	$(call step,Show docker-compose config...\n)
 	$(call docker_compose,config)
 
+PHONY += pull
+pull: ## Pull docker images
+	$(call step,Pull the latest docker images...\n)
+	$(call docker_compose,pull)
+
 PHONY += down
 down: ## Tear down the environment
 	$(call step,Tear down the environment...\n)
@@ -34,7 +39,7 @@ stop: ## Stop the environment
 	$(call docker_compose,stop)
 
 PHONY += up
-up: ## Launch the environment
+up: pull ## Launch the environment
 	$(call step,Start up the container(s)...\n)
 	$(call docker_compose,up -d --remove-orphans --quiet-pull)
 

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -36,7 +36,7 @@ stop: ## Stop the environment
 PHONY += up
 up: ## Launch the environment
 	$(call step,Start up the container(s)...\n)
-	$(call docker_compose,up -d --remove-orphans)
+	$(call docker_compose,up -d --remove-orphans --quiet-pull)
 
 PHONY += shell
 shell: ## Login to CLI container

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -41,7 +41,7 @@ stop: ## Stop the environment
 PHONY += up
 up: pull ## Launch the environment
 	$(call step,Start up the container(s)...\n)
-	$(call docker_compose,up -d --remove-orphans --quiet-pull)
+	$(call docker_compose,up -d --remove-orphans)
 
 PHONY += shell
 shell: ## Login to CLI container

--- a/tests/outputs/docker-up.txt
+++ b/tests/outputs/docker-up.txt
@@ -3,4 +3,4 @@ up RUN_ON=docker
 printf "\n⭐ \033[0;33mPull the latest docker images...\n\033[0m\n"
 docker-compose pull
 printf "\n⭐ \033[0;33mStart up the container(s)...\n\033[0m\n"
-docker-compose up -d --remove-orphans --quiet-pull
+docker-compose up -d --remove-orphans

--- a/tests/outputs/docker-up.txt
+++ b/tests/outputs/docker-up.txt
@@ -1,4 +1,4 @@
 up RUN_ON=docker
 ---
 printf "\n⭐ \033[0;33mStart up the container(s)...\n\033[0m\n"
-docker-compose up -d --remove-orphans
+docker-compose up -d --remove-orphans --quiet-pull

--- a/tests/outputs/docker-up.txt
+++ b/tests/outputs/docker-up.txt
@@ -1,4 +1,6 @@
 up RUN_ON=docker
 ---
+printf "\n⭐ \033[0;33mPull the latest docker images...\n\033[0m\n"
+docker-compose pull
 printf "\n⭐ \033[0;33mStart up the container(s)...\n\033[0m\n"
 docker-compose up -d --remove-orphans --quiet-pull


### PR DESCRIPTION
Images are no longer pulled on `make up` since this commit: https://github.com/druidfi/tools/commit/829377cc255c92de3b4fe6b8118dc6fc1e1f34da#diff-0c1f3d7d15033bb35ec268ee26d3024bf0a9238dc5ea213f26c0ddee4a0f7d87L27
